### PR TITLE
Explicitly list dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,10 @@
         "php": ">=5.4.0",
         "guzzle/parser": "~3.0",
         "react/socket-client": "0.4.*",
-        "react/dns": "0.4.*"
+        "react/dns": "0.4.*",
+        "react/event-loop": "0.4.*",
+        "react/stream": "0.4.*",
+        "evenement/evenement": "~2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The code has an explicit dependency on React's `stream` and `event-loop` components and `evenement`, hence we should explicitly define them as a dependency.

Currently, they're (implicitly) installed as part of a dependency of the `socket-client` component. IMHO this is an implementation detail that we should not rely on.

The resulting dependency graph looks like this:
![graph-composer](https://cloud.githubusercontent.com/assets/776829/3223534/f054a8be-f023-11e3-9d92-358deb0aa6ba.png)
