### PR TITLE
Removing HTTP 1.0 protocol

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -66,7 +66,6 @@ class Request implements WritableStreamInterface
                     $stream->on('end', array($this, 'handleEnd'));
                     $stream->on('error', array($this, 'handleError'));
 
-                    $requestData->setProtocolVersion('1.0');
                     $headers = (string) $requestData;
 
                     $stream->write($headers);


### PR DESCRIPTION
I want to use http-client with HTTP/1.1 protocol but this line is forcing HTTP/1.0. It could be great to let us choose of the protocol version.
