### PR TITLE
Changed Stream to DuplexStreamInterface in Response::__construct

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -3,8 +3,8 @@
 namespace React\HttpClient;
 
 use Evenement\EventEmitterTrait;
+use React\Stream\DuplexStreamInterface;
 use React\Stream\ReadableStreamInterface;
-use React\Stream\Stream;
 use React\Stream\Util;
 use React\Stream\WritableStreamInterface;
 
@@ -25,7 +25,7 @@ class Response implements ReadableStreamInterface
     private $headers;
     private $readable = true;
 
-    public function __construct(Stream $stream, $protocol, $version, $code, $reasonPhrase, $headers)
+    public function __construct(DuplexStreamInterface $stream, $protocol, $version, $code, $reasonPhrase, $headers)
     {
         $this->stream = $stream;
         $this->protocol = $protocol;


### PR DESCRIPTION
Https does not work without this:

Catchable fatal error: Argument 1 passed to React\HttpClient\Response::__construct() must be an instance of React\Stream\Stream, instance of React\SocketClient\SecureStream given, called in /Users/matt/PhpstormProjects/httpsClient/vendor/react/http-client/src/Request.php on line 239 and defined in /Users/matt/PhpstormProjects/httpsClient/vendor/react/http-client/src/Response.php on line 28
