### PR TITLE
changed "guzzle/parser" to "guzzle/guzzle"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.4.0",
-        "guzzle/parser": "~3.0",
+        "guzzle/guzzle": "~3.0",
         "react/socket-client": "0.4.*",
         "react/dns": "0.4.*",
         "react/event-loop": "0.4.*",


### PR DESCRIPTION
as far as 

```
This package is abandoned and no longer maintained. The author suggests using the guzzle/guzzle package instead.
```