### PR TITLE
Small fix to emitter of 'data' event

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,17 @@ Interesting events emitted by Request:
 
 * `response`: The response headers were received from the server and successfully
   parsed. The first argument is a Response instance.
-* `error`: An error occured.
-* `end`: The request is finished. If an error occured, it is passed as first
+* `error`: An error occurred.
+* `end`: The request is finished. If an error occurred, it is passed as first
   argument. Second and third arguments are the Response and the Request.
 
 Interesting events emitted by Response:
 
-* `data`: Passes a chunk of the response body as first argument
-* `error`: An error occured.
+* `data`: Passes a chunk of the response body as first argument and a Response
+  object itself as second argument.
+* `error`: An error occurred.
 * `end`: The response has been fully received. If an error
-  occured, it is passed as first argument
+  occurred, it is passed as first argument.
 
 ### Example
 
@@ -43,7 +44,7 @@ $client = $factory->create($loop, $dnsResolver);
 
 $request = $client->request('GET', 'https://github.com/');
 $request->on('response', function ($response) {
-    $response->on('data', function ($data) {
+    $response->on('data', function ($data, $response) {
         // ...
     });
 });

--- a/src/Request.php
+++ b/src/Request.php
@@ -147,7 +147,7 @@ class Request implements WritableStreamInterface
 
             $this->emit('response', array($response, $this));
 
-            $response->emit('data', array($bodyChunk));
+            $response->emit('data', array($bodyChunk, $response));
         }
     }
 

--- a/src/Response.php
+++ b/src/Response.php
@@ -9,7 +9,7 @@ use React\Stream\Util;
 use React\Stream\WritableStreamInterface;
 
 /**
- * @event data
+ * @event data ($bodyChunk, Response $thisResponse)
  * @event error
  * @event end
  */

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -71,7 +71,7 @@ class RequestTest extends TestCase
 
         $response->expects($this->once())
             ->method('emit')
-            ->with('data', array('body'));
+            ->with('data', array('body', $response));
 
         $response->expects($this->at(0))
             ->method('on')


### PR DESCRIPTION
I believe the $response parameter should be added to not miss very first chunk of data.

Proposed change makes code to work in the same way as the following line 
$response->emit('data', array($bodyChunk, $response));
in the Response::handleData function.