### PR TITLE
Store response data as property of Response object

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,13 @@ $factory = new React\HttpClient\Factory();
 $client = $factory->create($loop, $dnsResolver);
 
 $request = $client->request('GET', 'https://github.com/');
-$request->on('response', function ($response) {
-    $response->on('data', function ($data) {
+$request->on('end', function ($error, $response) {
+    if ($error) {
         // ...
-    });
+    } else {
+        $data = $response->getContent();
+        // ...
+    }
 });
 $request->end();
 $loop->run();

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ $factory = new React\HttpClient\Factory();
 $client = $factory->create($loop, $dnsResolver);
 
 $request = $client->request('GET', 'https://github.com/');
+
+// Either process the data in chunks as it arrives...
+$request->on('response', function ($response) {
+    $response->on('data', function ($data) {
+        // ...
+    });
+});
+// ...or store the entire response body, and process it on completion.
+$request->on('response', function ($response) {
+    $response->enableContentStore(true);
+});
 $request->on('end', function ($error, $response) {
     if ($error) {
         // ...
@@ -50,6 +61,7 @@ $request->on('end', function ($error, $response) {
         // ...
     }
 });
+
 $request->end();
 $loop->run();
 ```

--- a/src/Request.php
+++ b/src/Request.php
@@ -147,7 +147,7 @@ class Request implements WritableStreamInterface
 
             $this->emit('response', array($response, $this));
 
-            $response->emit('data', array($bodyChunk));
+            $response->handleData($bodyChunk);
         }
     }
 

--- a/src/Response.php
+++ b/src/Response.php
@@ -23,8 +23,9 @@ class Response implements ReadableStreamInterface
     private $code;
     private $reasonPhrase;
     private $headers;
-    private $content = '';
+    private $content;
     private $readable = true;
+    private $saveContent = false;
 
     public function __construct(DuplexStreamInterface $stream, $protocol, $version, $code, $reasonPhrase, $headers)
     {
@@ -70,9 +71,17 @@ class Response implements ReadableStreamInterface
         return $this->content;
     }
 
+    public function enableContentStore($enabled)
+    {
+        $this->saveContent = (bool) $enabled;
+    }
+
     public function handleData($data)
     {
-        $this->content .= $data;
+        if ($this->saveContent) {
+            $this->content .= $data;
+        }
+
         $this->emit('data', array($data, $this));
     }
 

--- a/src/Response.php
+++ b/src/Response.php
@@ -23,6 +23,7 @@ class Response implements ReadableStreamInterface
     private $code;
     private $reasonPhrase;
     private $headers;
+    private $content = '';
     private $readable = true;
 
     public function __construct(DuplexStreamInterface $stream, $protocol, $version, $code, $reasonPhrase, $headers)
@@ -64,8 +65,14 @@ class Response implements ReadableStreamInterface
         return $this->headers;
     }
 
+    public function getContent()
+    {
+        return $this->content;
+    }
+
     public function handleData($data)
     {
+        $this->content .= $data;
         $this->emit('data', array($data, $this));
     }
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -70,8 +70,8 @@ class RequestTest extends TestCase
         $response = $this->response;
 
         $response->expects($this->once())
-            ->method('emit')
-            ->with('data', array('body'));
+            ->method('handleData')
+            ->with('body');
 
         $response->expects($this->at(0))
             ->method('on')


### PR DESCRIPTION
Currently, after the creation of the response object, the only way to access data received from the stream is to construct a buffer and feed into it data received from the response object's `'data'` events. This is cumbersome, and the vast vast majority of uses for the client will only necessitate receiving the contents of the response in full once the request has been fully served.

To that end, this changeset stores the data buffer as a property of the `Response` object, accessible with a getter function as per other response attributes. With this functionality, accessing the HTTP response content is transformed from the complicated process of setting callback handlers to process the creation of the response object and receiving chunked data, to something akin to the following:

``` php
$request = $client->request('GET', 'https://github.com/reactphp/http-client/');
$request->on('end', function ($error, $response) {
    // error handling...

    $data = $response->getContent();
    // process the data
});
$request->end();
```

I will leave this here for more experienced eyes to consider. Feel free to cherry-pick or modify.
