### PR TITLE
Avoid hidding exceptions thrown in HttpClient\Request error handlers

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -57,7 +57,7 @@ class Request implements WritableStreamInterface
 
         $this
             ->connect()
-            ->then(
+            ->done(
                 function ($stream) use ($requestData, &$streamRef, &$stateRef) {
                     $streamRef = $stream;
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -217,6 +217,25 @@ class RequestTest extends TestCase
         $request->handleError(new \Exception('test'));
     }
 
+    /**
+     * @test
+     * @expectedException Exception
+     * @expectedExceptionMessage something failed
+     */
+    public function requestDoesNotHideErrors()
+    {
+        $requestData = new RequestData('GET', 'http://www.example.com');
+        $request = new Request($this->connector, $requestData);
+
+        $this->rejectedConnectionMock();
+
+        $request->on('error', function () {
+            throw new \Exception('something failed');
+        });
+
+        $request->end();
+    }
+
     /** @test */
     public function postRequestShouldSendAPostRequest()
     {


### PR DESCRIPTION
`then()` catches exceptions, which is not desirable when its result is not returned.

The following code throws an exception in the 'error' event handler. However, the exception is caught because the event is fired in a `then()` callback.

This PR fixes this by changing a `then` to a `done`.

``` php
$requestData = new RequestData('GET', 'http://www.example.com');
$request = new Request($this->connector, $requestData);

$request->on('error', function () {
    throw new \Exception();
});

$request->end();
```

Actual use case:

``` php
$requestData = new RequestData('GET', 'http://www.example.com');
$request = new Request($this->connector, $requestData);

$deferred = new Deferred();

$request->on('error', function ($err) use ($deferred) {
    $deferred->reject($err);
});

$deferred->done(); // Throws an exception if the deferred is rejected.
                   // Without the PR, the exception is caught.

$request->end();
```