### PR TITLE
Add support for using auth informations from URL

### DIFF
--- a/src/RequestData.php
+++ b/src/RequestData.php
@@ -21,6 +21,7 @@ class RequestData
     {
         $port = ($this->getDefaultPort() === $this->getPort()) ? '' : ":{$this->getPort()}";
         $connectionHeaders = ('1.1' === $this->protocolVersion) ? array('Connection' => 'close') : array();
+        $authHeaders = $this->getAuthHeaders();
 
         return array_merge(
             array(
@@ -28,6 +29,7 @@ class RequestData
                 'User-Agent'    => 'React/alpha',
             ),
             $connectionHeaders,
+            $authHeaders,
             $headers
         );
     }
@@ -77,5 +79,28 @@ class RequestData
         $data .= "\r\n";
 
         return $data;
+    }
+
+    private function getUrlUserPass()
+    {
+        $components = parse_url($this->url);
+
+        if (isset($components['user'])) {
+            return array(
+                'user' => $components['user'],
+                'pass' => isset($components['pass']) ? $components['pass'] : null,
+            );
+        }
+    }
+
+    private function getAuthHeaders()
+    {
+        if (null !== $auth = $this->getUrlUserPass()) {
+            return array(
+                'Authorization' => 'Basic ' . base64_encode($auth['user'].':'.$auth['pass']),
+            );
+        }
+
+        return array();
     }
 }

--- a/tests/RequestDataTest.php
+++ b/tests/RequestDataTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace React\Tests\HttpClient;
+
+use React\HttpClient\RequestData;
+
+class RequestDataTest extends TestCase
+{
+    /** @test */
+    public function toStringReturnsHTTPRequestMessage()
+    {
+        $requestData = new RequestData('GET', 'http://www.example.com');
+
+        $expected = "GET / HTTP/1.1\r\n" .
+            "Host: www.example.com\r\n" .
+            "User-Agent: React/alpha\r\n" .
+            "Connection: close\r\n" .
+            "\r\n";
+
+        $this->assertSame($expected, $requestData->__toString());
+    }
+
+    /** @test */
+    public function toStringUsesUserPassFromURL()
+    {
+        $requestData = new RequestData('GET', 'http://john:dummy@www.example.com');
+
+        $expected = "GET / HTTP/1.1\r\n" .
+            "Host: www.example.com\r\n" .
+            "User-Agent: React/alpha\r\n" .
+            "Connection: close\r\n" .
+            "Authorization: Basic am9objpkdW1teQ==\r\n" .
+            "\r\n";
+
+        $this->assertSame($expected, $requestData->__toString());
+    }
+}


### PR DESCRIPTION
This changes RequestData such that if the provided URL contains a user and optionally a password, they will be used for generating an `Authorization: Basic ...` header.