### PR TITLE
Replace the abandoned guzzle/parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.4.0",
-        "guzzle/parser": "~3.0",
+        "guzzlehttp/psr7": "^1.0",
         "react/socket-client": "0.4.*",
         "react/dns": "0.4.*",
         "react/event-loop": "0.4.*",

--- a/src/Request.php
+++ b/src/Request.php
@@ -3,7 +3,7 @@
 namespace React\HttpClient;
 
 use Evenement\EventEmitterTrait;
-use Guzzle\Parser\Message\MessageParser;
+use GuzzleHttp\Psr7 as g7;
 use React\SocketClient\ConnectorInterface;
 use React\Stream\WritableStreamInterface;
 
@@ -203,20 +203,25 @@ class Request implements WritableStreamInterface
 
     protected function parseResponse($data)
     {
-        $parser = new MessageParser();
-        $parsed = $parser->parseResponse($data);
+        $psrResponse = g7\parse_response($data);
+        $headers = $psrResponse->getHeaders();
+        array_walk($headers, function(&$val) {
+            if (1 === count($val)) {
+                $val = $val[0];
+            }
+        });
 
         $factory = $this->getResponseFactory();
 
         $response = $factory(
-            $parsed['protocol'],
-            $parsed['version'],
-            $parsed['code'],
-            $parsed['reason_phrase'],
-            $parsed['headers']
+            'HTTP',
+            $psrResponse->getProtocolVersion(),
+            $psrResponse->getStatusCode(),
+            $psrResponse->getReasonPhrase(),
+            $headers
         );
 
-        return array($response, $parsed['body']);
+        return array($response, $psrResponse->getBody());
     }
 
     protected function connect()

--- a/src/Request.php
+++ b/src/Request.php
@@ -3,7 +3,7 @@
 namespace React\HttpClient;
 
 use Evenement\EventEmitterTrait;
-use GuzzleHttp\Psr7 as g7;
+use GuzzleHttp\Psr7 as gPsr;
 use React\SocketClient\ConnectorInterface;
 use React\Stream\WritableStreamInterface;
 
@@ -203,7 +203,7 @@ class Request implements WritableStreamInterface
 
     protected function parseResponse($data)
     {
-        $psrResponse = g7\parse_response($data);
+        $psrResponse = gPsr\parse_response($data);
         $headers = $psrResponse->getHeaders();
         array_walk($headers, function(&$val) {
             if (1 === count($val)) {

--- a/src/Request.php
+++ b/src/Request.php
@@ -204,12 +204,13 @@ class Request implements WritableStreamInterface
     protected function parseResponse($data)
     {
         $psrResponse = gPsr\parse_response($data);
-        $headers = $psrResponse->getHeaders();
-        array_walk($headers, function(&$val) {
+        $headers = array_map(function(&$val) {
             if (1 === count($val)) {
                 $val = $val[0];
             }
-        });
+
+            return $val;
+        }, $psrResponse->getHeaders());
 
         $factory = $this->getResponseFactory();
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -204,7 +204,7 @@ class Request implements WritableStreamInterface
     protected function parseResponse($data)
     {
         $psrResponse = gPsr\parse_response($data);
-        $headers = array_map(function(&$val) {
+        $headers = array_map(function($val) {
             if (1 === count($val)) {
                 $val = $val[0];
             }


### PR DESCRIPTION
fixes #23
overrules #26

This replaces the old abandoned guzzle/parser with guzzlehttp/psr7 