### PR TITLE
Remove hhvm-nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,11 @@ php:
   - 5.6
   - 7
   - hhvm
-  - hhvm-nightly
 
 matrix:
   allow_failures:
     - php: 7
     - php: hhvm
-    - php: hhvm-nightly
 
 before_script:
   - composer install --dev --prefer-source


### PR DESCRIPTION
hhvm-nightly isn't supported on travis anymore, as shown per error message: https://travis-ci.org/reactphp/http-client/jobs/76790406 