### PR TITLE
Support explicitly using HTTP/1.1 protocol version

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -68,7 +68,6 @@ class Request implements WritableStreamInterface
                     $stream->on('end', array($this, 'handleEnd'));
                     $stream->on('error', array($this, 'handleError'));
 
-                    $requestData->setProtocolVersion('1.0');
                     $headers = (string) $requestData;
 
                     $stream->write($headers);

--- a/src/RequestData.php
+++ b/src/RequestData.php
@@ -8,7 +8,7 @@ class RequestData
     private $url;
     private $headers;
 
-    private $protocolVersion = '1.1';
+    private $protocolVersion = '1.0';
 
     public function __construct($method, $url, array $headers = [])
     {

--- a/tests/RequestDataTest.php
+++ b/tests/RequestDataTest.php
@@ -11,6 +11,20 @@ class RequestDataTest extends TestCase
     {
         $requestData = new RequestData('GET', 'http://www.example.com');
 
+        $expected = "GET / HTTP/1.0\r\n" .
+            "Host: www.example.com\r\n" .
+            "User-Agent: React/alpha\r\n" .
+            "\r\n";
+
+        $this->assertSame($expected, $requestData->__toString());
+    }
+
+    /** @test */
+    public function toStringReturnsHTTPRequestMessageWithProtocolVersion()
+    {
+        $requestData = new RequestData('GET', 'http://www.example.com');
+        $requestData->setProtocolVersion('1.1');
+
         $expected = "GET / HTTP/1.1\r\n" .
             "Host: www.example.com\r\n" .
             "User-Agent: React/alpha\r\n" .
@@ -25,10 +39,9 @@ class RequestDataTest extends TestCase
     {
         $requestData = new RequestData('GET', 'http://john:dummy@www.example.com');
 
-        $expected = "GET / HTTP/1.1\r\n" .
+        $expected = "GET / HTTP/1.0\r\n" .
             "Host: www.example.com\r\n" .
             "User-Agent: React/alpha\r\n" .
-            "Connection: close\r\n" .
             "Authorization: Basic am9objpkdW1teQ==\r\n" .
             "\r\n";
 


### PR DESCRIPTION
Still defaults to HTTP/1.0 and offers only limited support for HTTP/1.1

Closes #5.