### PR TITLE
Set protocol version on request creation

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -15,9 +15,9 @@ class Client
         $this->secureConnector = $secureConnector;
     }
 
-    public function request($method, $url, array $headers = [])
+    public function request($method, $url, array $headers = [], $protocolVersion = '1.0')
     {
-        $requestData = new RequestData($method, $url, $headers);
+        $requestData = new RequestData($method, $url, $headers, $protocolVersion);
         $connector = $this->getConnectorForScheme($requestData->getScheme());
 
         return new Request($connector, $requestData);

--- a/src/RequestData.php
+++ b/src/RequestData.php
@@ -7,14 +7,14 @@ class RequestData
     private $method;
     private $url;
     private $headers;
+    private $protocolVersion;
 
-    private $protocolVersion = '1.0';
-
-    public function __construct($method, $url, array $headers = [])
+    public function __construct($method, $url, array $headers = [], $protocolVersion = '1.0')
     {
         $this->method = $method;
         $this->url = $url;
         $this->headers = $headers;
+        $this->protocolVersion = $protocolVersion;
     }
 
     private function mergeDefaultheaders(array $headers)

--- a/tests/RequestDataTest.php
+++ b/tests/RequestDataTest.php
@@ -35,6 +35,20 @@ class RequestDataTest extends TestCase
     }
 
     /** @test */
+    public function toStringReturnsHTTPRequestMessageWithProtocolVersionThroughConstructor()
+    {
+        $requestData = new RequestData('GET', 'http://www.example.com', [], '1.1');
+
+        $expected = "GET / HTTP/1.1\r\n" .
+            "Host: www.example.com\r\n" .
+            "User-Agent: React/alpha\r\n" .
+            "Connection: close\r\n" .
+            "\r\n";
+
+        $this->assertSame($expected, $requestData->__toString());
+    }
+
+    /** @test */
     public function toStringUsesUserPassFromURL()
     {
         $requestData = new RequestData('GET', 'http://john:dummy@www.example.com');


### PR DESCRIPTION
Follow up for #43 and fixes #47. This way a user can present it self as a HTTP1.1 client.