### PR TITLE
gzip and deflate content encoding decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ $loop->run();
 
 ## TODO
 
-* gzip content encoding
 * chunked transfer encoding
 * keep-alive connections
 * following redirections

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "react/event-loop": "0.4.*",
         "react/stream": "0.4.*",
         "react/promise": "~2.2",
-        "evenement/evenement": "~2.0"
+        "evenement/evenement": "~2.0",
+        "clue/zlib-react": "^0.1.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Request.php
+++ b/src/Request.php
@@ -156,7 +156,7 @@ class Request implements WritableStreamInterface
 
             $this->emit('response', array($response, $this));
 
-            $response->emit('data', array($bodyChunk, $response));
+            $this->stream->emit('data', array($bodyChunk));
         }
     }
 
@@ -238,10 +238,14 @@ class Request implements WritableStreamInterface
         $this->responseFactory = $factory;
     }
 
-    public function getResponseFactory()
+    public function getResponseFactory($psrResponse = null)
     {
         if (null === $factory = $this->responseFactory) {
             $stream = $this->stream;
+
+            if ($psrResponse != null) {
+                $stream = StreamDecoder::detect($stream, $psrResponse);
+            }
 
             $factory = function ($protocol, $version, $code, $reasonPhrase, $headers) use ($stream) {
                 return new Response(

--- a/src/RequestData.php
+++ b/src/RequestData.php
@@ -25,8 +25,9 @@ class RequestData
 
         return array_merge(
             array(
-                'Host'          => $this->getHost().$port,
-                'User-Agent'    => 'React/alpha',
+                'Host'            => $this->getHost().$port,
+                'User-Agent'      => 'React/alpha',
+                'Accept-Encoding' => 'gzip',
             ),
             $connectionHeaders,
             $authHeaders,

--- a/src/StreamDecoder.php
+++ b/src/StreamDecoder.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace React\HttpClient;
+
+use Clue\React\Zlib\ZlibFilterStream;
+use GuzzleHttp\Psr7\Response as psr7Response;
+use React\Stream\DuplexStreamInterface;
+
+class StreamDecoder
+{
+    public static function detect(DuplexStreamInterface $stream, psr7Response $response)
+    {
+        if ($response->hasHeader('content-encoding')) {
+            $stream = static::contentEncoding($stream, $response->getHeaderLine('content-encoding'));
+        }
+
+        return $stream;
+    }
+
+    protected static function contentEncoding($stream, $encoding)
+    {
+        if ($encoding == 'gzip') {
+            return $stream->pipe(ZlibFilterStream::createGzipDecompressor());
+        }
+
+        if ($encoding == 'deflate') {
+            return $stream->pipe(ZlibFilterStream::createDeflateDecompressor());
+        }
+
+        return $stream;
+    }
+}

--- a/tests/RequestDataTest.php
+++ b/tests/RequestDataTest.php
@@ -14,6 +14,7 @@ class RequestDataTest extends TestCase
         $expected = "GET / HTTP/1.0\r\n" .
             "Host: www.example.com\r\n" .
             "User-Agent: React/alpha\r\n" .
+            "Accept-Encoding: gzip\r\n" .
             "\r\n";
 
         $this->assertSame($expected, $requestData->__toString());
@@ -28,6 +29,7 @@ class RequestDataTest extends TestCase
         $expected = "GET / HTTP/1.1\r\n" .
             "Host: www.example.com\r\n" .
             "User-Agent: React/alpha\r\n" .
+            "Accept-Encoding: gzip\r\n" .
             "Connection: close\r\n" .
             "\r\n";
 
@@ -42,6 +44,7 @@ class RequestDataTest extends TestCase
         $expected = "GET / HTTP/1.1\r\n" .
             "Host: www.example.com\r\n" .
             "User-Agent: React/alpha\r\n" .
+            "Accept-Encoding: gzip\r\n" .
             "Connection: close\r\n" .
             "\r\n";
 
@@ -56,6 +59,7 @@ class RequestDataTest extends TestCase
         $expected = "GET / HTTP/1.0\r\n" .
             "Host: www.example.com\r\n" .
             "User-Agent: React/alpha\r\n" .
+            "Accept-Encoding: gzip\r\n" .
             "Authorization: Basic am9objpkdW1teQ==\r\n" .
             "\r\n";
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -68,12 +68,12 @@ class RequestTest extends TestCase
             ->expects($this->at(8))
             ->method('removeListener')
             ->with('error', $this->identicalTo(array($request, 'handleError')));
+        $this->stream
+            ->expects($this->at(9))
+            ->method('emit')
+            ->with('data', array('body'));
 
         $response = $this->response;
-
-        $response->expects($this->once())
-            ->method('emit')
-            ->with('data', array('body', $response));
 
         $response->expects($this->at(0))
             ->method('on')
@@ -249,7 +249,7 @@ class RequestTest extends TestCase
         $this->stream
             ->expects($this->at(4))
             ->method('write')
-            ->with($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\nUser-Agent:.*\r\n\r\n$#"));
+            ->with($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\nUser-Agent:.*\r\nAccept-Encoding: gzip\r\n\r\n$#"));
         $this->stream
             ->expects($this->at(5))
             ->method('write')
@@ -279,7 +279,7 @@ class RequestTest extends TestCase
         $this->stream
             ->expects($this->at(4))
             ->method('write')
-            ->with($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\nUser-Agent:.*\r\n\r\n$#"));
+            ->with($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\nUser-Agent:.*\r\nAccept-Encoding: gzip\r\n\r\n$#"));
         $this->stream
             ->expects($this->at(5))
             ->method('write')
@@ -320,7 +320,7 @@ class RequestTest extends TestCase
         $this->stream
             ->expects($this->at(4))
             ->method('write')
-            ->with($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\nUser-Agent:.*\r\n\r\n$#"));
+            ->with($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\nUser-Agent:.*\r\nAccept-Encoding: gzip\r\n\r\n$#"));
         $this->stream
             ->expects($this->at(5))
             ->method('write')
@@ -367,7 +367,7 @@ class RequestTest extends TestCase
         $this->stream
             ->expects($this->at(4))
             ->method('write')
-            ->with($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\nUser-Agent:.*\r\n\r\n$#"));
+            ->with($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\nUser-Agent:.*\r\nAccept-Encoding: gzip\r\n\r\n$#"));
         $this->stream
             ->expects($this->at(5))
             ->method('write')

--- a/tests/StreamDecoderTest.php
+++ b/tests/StreamDecoderTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace React\Tests\HttpClient;
+
+use GuzzleHttp\Psr7\Response as psr7Response;
+use React\HttpClient\StreamDecoder;
+use React\Stream\ThroughStream;
+
+class StreamDecoderTest extends TestCase
+{
+    public function providerDetect()
+    {
+        return [
+            [
+                new psr7Response(200),
+                'React\Stream\ThroughStream',
+            ],
+            [
+                new psr7Response(200, [
+                    'Content-Encoding' => [
+                        'gzip'
+                    ],
+                ]),
+                'Clue\React\Zlib\ZlibFilterStream',
+            ],
+            [
+                new psr7Response(200, [
+                    'Content-Encoding' => [
+                        'deflate'
+                    ],
+                ]),
+                'Clue\React\Zlib\ZlibFilterStream',
+            ],
+            [
+                new psr7Response(200, [
+                    'Content-Encoding' => [
+                        'foobar'
+                    ],
+                ]),
+                'React\Stream\ThroughStream',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerDetect
+     */
+    public function testDetect($response, $instanceOf)
+    {
+        $stream = StreamDecoder::detect(new ThroughStream(), $response);
+        $this->assertInstanceOf($instanceOf, $stream);
+    }
+}


### PR DESCRIPTION
Using [`clue/zlib-react`](https://github.com/clue/php-zlib-react) this PR adds gzip and deflate content encoding decoding and paves the way chunked encoding decoding and the likes of it.

Fixes #30
