### PR TITLE
Add basic proxy support

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -15,12 +15,12 @@ class Client
         $this->secureConnector = $secureConnector;
     }
 
-    public function request($method, $url, array $headers = [], $protocolVersion = '1.0')
+    public function request($method, $url, array $headers = [], $protocolVersion = '1.0', ProxyConfig $proxyConfig = null)
     {
         $requestData = new RequestData($method, $url, $headers, $protocolVersion);
         $connector = $this->getConnectorForScheme($requestData->getScheme());
 
-        return new Request($connector, $requestData);
+        return new Request($connector, $requestData, $proxyConfig);
     }
 
     private function getConnectorForScheme($scheme)

--- a/src/ProxyConfig.php
+++ b/src/ProxyConfig.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace React\HttpClient;
+
+class ProxyConfig
+{
+    public $host;
+    public $port;
+
+    public function __construct($host, $port)
+    {
+        $this->host = $host;
+        $this->port = $port;
+    }
+}

--- a/src/Request.php
+++ b/src/Request.php
@@ -25,6 +25,7 @@ class Request implements WritableStreamInterface
 
     private $connector;
     private $requestData;
+    private $proxyConfig;
 
     private $stream;
     private $buffer;
@@ -34,10 +35,11 @@ class Request implements WritableStreamInterface
 
     private $pendingWrites = array();
 
-    public function __construct(ConnectorInterface $connector, RequestData $requestData)
+    public function __construct(ConnectorInterface $connector, RequestData $requestData, ProxyConfig $proxyConfig = null)
     {
         $this->connector = $connector;
         $this->requestData = $requestData;
+        $this->proxyConfig = $proxyConfig;
     }
 
     public function isWritable()
@@ -68,7 +70,12 @@ class Request implements WritableStreamInterface
                     $stream->on('end', array($this, 'handleEnd'));
                     $stream->on('error', array($this, 'handleError'));
 
-                    $headers = (string) $requestData;
+                    $requestData->setProtocolVersion('1.0');
+                    if (null !== $this->proxyConfig) {
+                        $headers = $requestData->toStringAbsolute();
+                    } else {
+                        $headers = $requestData->toString();
+                    }
 
                     $stream->write($headers);
 
@@ -226,8 +233,13 @@ class Request implements WritableStreamInterface
 
     protected function connect()
     {
-        $host = $this->requestData->getHost();
-        $port = $this->requestData->getPort();
+        if (null !== $proxyConfig = $this->proxyConfig) {
+            $host = $proxyConfig->host;
+            $port = $proxyConfig->port;
+        } else {
+            $host = $this->requestData->getHost();
+            $port = $this->requestData->getPort();
+        }
 
         return $this->connector
             ->create($host, $port);

--- a/src/RequestData.php
+++ b/src/RequestData.php
@@ -67,20 +67,6 @@ class RequestData
         $this->protocolVersion = $version;
     }
 
-    public function __toString()
-    {
-        $headers = $this->mergeDefaultheaders($this->headers);
-
-        $data = '';
-        $data .= "{$this->method} {$this->getPath()} HTTP/{$this->protocolVersion}\r\n";
-        foreach ($headers as $name => $value) {
-            $data .= "$name: $value\r\n";
-        }
-        $data .= "\r\n";
-
-        return $data;
-    }
-
     private function getUrlUserPass()
     {
         $components = parse_url($this->url);
@@ -102,5 +88,34 @@ class RequestData
         }
 
         return array();
+    }
+
+    public function toStringURI($uri)
+    {
+        $headers = $this->mergeDefaultheaders($this->headers);
+
+        $data = '';
+        $data .= "{$this->method} {$uri} HTTP/{$this->protocolVersion}\r\n";
+        foreach ($headers as $name => $value) {
+            $data .= "$name: $value\r\n";
+        }
+        $data .= "\r\n";
+
+        return $data;
+    }
+
+    public function toString()
+    {
+        return $this->toStringURI($this->getPath());
+    }
+
+    public function toStringAbsolute()
+    {
+        return $this->toStringURI($this->url);
+    }
+
+    public function __toString()
+    {
+        return $this->toString();
     }
 }


### PR DESCRIPTION
This adds basic proxy support to the HTTP client:

``` php
<?php
$proxyConfig = new ProxyConfig("127.0.0.1", 3128);
$request = $client->request("GET", "http://example.com/", [], '1.0', $proxyConfig);
```
