### PR TITLE
Ensure the first bit of body directly after the headers is emitted into the stream

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -156,7 +156,7 @@ class Request implements WritableStreamInterface
 
             $this->emit('response', array($response, $this));
 
-            $response->emit('data', array($bodyChunk, $response));
+            $this->stream->emit('data', array($bodyChunk, $response));
         }
     }
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -156,7 +156,7 @@ class Request implements WritableStreamInterface
 
             $this->emit('response', array($response, $this));
 
-            $this->stream->emit('data', array($bodyChunk, $response));
+            $this->stream->emit('data', array($bodyChunk));
         }
     }
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -73,7 +73,7 @@ class RequestTest extends TestCase
 
         $this->stream->expects($this->once())
             ->method('emit')
-            ->with('data', $this->identicalTo(array('body', $response)));
+            ->with('data', $this->identicalTo(array('body')));
 
         $response->expects($this->at(0))
             ->method('on')
@@ -546,13 +546,7 @@ class RequestTest extends TestCase
 
         $this->stream->expects($this->once())
             ->method('emit')
-            ->with('data', $this->anything())
-            ->will($this->returnCallback(function ($event, $data) {
-                $this->assertTrue(is_array($data));
-                $this->assertSame(2, count($data));
-                $this->assertSame("1\r\nb\r", $data[0]);
-                $this->assertInstanceOf('React\HttpClient\Response', $data[1]);
-            }));
+            ->with('data', ["1\r\nb\r"]);
 
         $request->handleData("HTTP/1.0 200 OK\r\n");
         $request->handleData("Transfer-Encoding: chunked\r\n");


### PR DESCRIPTION
Fixes #67 

- [X] Fix bug (#67)
- [X] Add test case for bug