### PR TITLE
Trim leading zeros from chunk size, Varnish Cache problem

### DIFF
--- a/src/ChunkedStreamDecoder.php
+++ b/src/ChunkedStreamDecoder.php
@@ -111,6 +111,7 @@ class ChunkedStreamDecoder implements ReadableStreamInterface
             if (strpos($lengthChunk, ';') !== false) {
                 list($lengthChunk) = explode(';', $lengthChunk, 2);
             }
+            $lengthChunk = ltrim($lengthChunk, "0");
             if (dechex(hexdec($lengthChunk)) !== $lengthChunk) {
                 $this->emit('error', [
                     new Exception('Unable to validate "' . $lengthChunk . '" as chunk length header'),

--- a/src/ChunkedStreamDecoder.php
+++ b/src/ChunkedStreamDecoder.php
@@ -111,7 +111,12 @@ class ChunkedStreamDecoder implements ReadableStreamInterface
             if (strpos($lengthChunk, ';') !== false) {
                 list($lengthChunk) = explode(';', $lengthChunk, 2);
             }
-            $lengthChunk = ltrim($lengthChunk, "0");
+            if ($lengthChunk !== '') {
+                $lengthChunk = ltrim($lengthChunk, "0");
+                if ($lengthChunk === '') {
+                    $lengthChunk = "0";
+                }
+            }
             if (dechex(hexdec($lengthChunk)) !== $lengthChunk) {
                 $this->emit('error', [
                     new Exception('Unable to validate "' . $lengthChunk . '" as chunk length header'),

--- a/tests/DecodeChunkedStreamTest.php
+++ b/tests/DecodeChunkedStreamTest.php
@@ -47,11 +47,23 @@ class DecodeChunkedStreamTest extends TestCase
                 ["0017\r\nWikipedia in\r\n\r\nchunks.\r\n0\r\n\r\n"]
             ],
             'varnish-type-response-2' => [
+                ["000017\r\nWikipedia in\r\n\r\nchunks.\r\n0\r\n\r\n"]
+            ],
+            'varnish-type-response-3' => [
+                ["017\r\nWikipedia in\r\n\r\nchunks.\r\n0\r\n\r\n"]
+            ],
+            'varnish-type-response-4' => [
                 ["004\r\nWiki\r\n005\r\npedia\r\n00e\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n"]
+            ],
+            'varnish-type-response-5' => [
+                ["000004\r\nWiki\r\n00005\r\npedia\r\n000e\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n"]
             ],
             'varnish-type-response-extra-line' => [
                 ["006\r\nWi\r\nki\r\n005\r\npedia\r\n00e\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n"],
                 "Wi\r\nkipedia in\r\n\r\nchunks."
+            ],
+            'varnish-type-response-random' => [
+                [str_repeat("0", rand(0, 10)), "4\r\nWiki\r\n", str_repeat("0", rand(0, 10)), "5\r\npedia\r\n", str_repeat("0", rand(0, 10)), "e\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n"]
             ]
         ];
     }

--- a/tests/DecodeChunkedStreamTest.php
+++ b/tests/DecodeChunkedStreamTest.php
@@ -64,6 +64,15 @@ class DecodeChunkedStreamTest extends TestCase
             ],
             'varnish-type-response-random' => [
                 [str_repeat("0", rand(0, 10)), "4\r\nWiki\r\n", str_repeat("0", rand(0, 10)), "5\r\npedia\r\n", str_repeat("0", rand(0, 10)), "e\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n"]
+            ],
+            'end-chunk-zero-check-1' => [
+                ["4\r\nWiki\r\n5\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n00\r\n\r\n"]
+            ],
+            'end-chunk-zero-check-2' => [
+                ["4\r\nWiki\r\n5\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n000\r\n\r\n"]
+            ],
+            'end-chunk-zero-check-3' => [
+                ["00004\r\nWiki\r\n005\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n0000\r\n\r\n"]
             ]
         ];
     }
@@ -100,15 +109,6 @@ class DecodeChunkedStreamTest extends TestCase
             ],
             'header-chunk-to-long' => [
                 str_split(str_repeat('a', 2015) . "\r\nWi\r\nki\r\n5\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n")
-            ],
-            'end-chunk-zero-check-1' => [
-                ["4\r\nWiki\r\n5\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n00\r\n\r\n"]
-            ],
-            'end-chunk-zero-check-2' => [
-                ["4\r\nWiki\r\n5\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n000\r\n\r\n"]
-            ],
-            'end-chunk-zero-check-3' => [
-                ["00004\r\nWiki\r\n005\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n0000\r\n\r\n"]
             ]
         ];
     }

--- a/tests/DecodeChunkedStreamTest.php
+++ b/tests/DecodeChunkedStreamTest.php
@@ -43,6 +43,16 @@ class DecodeChunkedStreamTest extends TestCase
                 ["6\r\nWi\r\n", "ki\r\n5\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n"],
                 "Wi\r\nkipedia in\r\n\r\nchunks."
             ],
+            'varnish-type-response-1' => [
+                ["0017\r\nWikipedia in\r\n\r\nchunks.\r\n0\r\n\r\n"]
+            ],
+            'varnish-type-response-2' => [
+                ["004\r\nWiki\r\n005\r\npedia\r\n00e\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n"]
+            ],
+            'varnish-type-response-extra-line' => [
+                ["006\r\nWi\r\nki\r\n005\r\npedia\r\n00e\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n"],
+                "Wi\r\nkipedia in\r\n\r\nchunks."
+            ]
         ];
     }
 

--- a/tests/DecodeChunkedStreamTest.php
+++ b/tests/DecodeChunkedStreamTest.php
@@ -101,6 +101,15 @@ class DecodeChunkedStreamTest extends TestCase
             'header-chunk-to-long' => [
                 str_split(str_repeat('a', 2015) . "\r\nWi\r\nki\r\n5\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n")
             ],
+            'end-chunk-zero-check-1' => [
+                ["4\r\nWiki\r\n5\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n00\r\n\r\n"]
+            ],
+            'end-chunk-zero-check-2' => [
+                ["4\r\nWiki\r\n5\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n000\r\n\r\n"]
+            ],
+            'end-chunk-zero-check-3' => [
+                ["00004\r\nWiki\r\n005\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n0000\r\n\r\n"]
+            ]
         ];
     }
 


### PR DESCRIPTION
Varnish Cache returns data with chunk size lead by 2 zeros `00`. Examples:

`00e` instead of `e`
`001` instead of `1`
`001234` instead of `1234`

Leading zeros have no value so we can trim them. I'm not 100% sure that there are always 2 zeros, but as far as I observed, there was 2 (to be sure I trim them all). Last zero is passed normally, so `\r\n0\r\n\r\n`.

Tests added.