### PR TITLE
Catch Guzzle parser exception

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -132,7 +132,13 @@ class Request implements WritableStreamInterface
         $this->buffer .= $data;
 
         if (false !== strpos($this->buffer, "\r\n\r\n")) {
-            list($response, $bodyChunk) = $this->parseResponse($this->buffer);
+            try {
+                list($response, $bodyChunk) = $this->parseResponse($this->buffer);
+            } catch (\InvalidArgumentException $exception) {
+                $this->emit('error', [$exception, $this]);
+
+                return;
+            }
 
             $this->buffer = null;
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -136,8 +136,6 @@ class Request implements WritableStreamInterface
                 list($response, $bodyChunk) = $this->parseResponse($this->buffer);
             } catch (\InvalidArgumentException $exception) {
                 $this->emit('error', [$exception, $this]);
-
-                return;
             }
 
             $this->buffer = null;
@@ -146,6 +144,10 @@ class Request implements WritableStreamInterface
             $this->stream->removeListener('data', array($this, 'handleData'));
             $this->stream->removeListener('end', array($this, 'handleEnd'));
             $this->stream->removeListener('error', array($this, 'handleError'));
+
+            if (!isset($response)) {
+                return;
+            }
 
             $this->response = $response;
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -220,6 +220,28 @@ class RequestTest extends TestCase
         $request->handleError(new \Exception('test'));
     }
 
+    /** @test */
+    public function requestShouldEmitErrorIfGuzzleParseThrowsException()
+    {
+        $requestData = new RequestData('GET', 'http://www.example.com');
+        $request = new Request($this->connector, $requestData);
+
+        $this->successfulConnectionMock();
+
+        $handler = $this->createCallableMock();
+        $handler->expects($this->once())
+            ->method('__invoke')
+            ->with(
+                $this->isInstanceOf('\InvalidArgumentException'),
+                $this->isInstanceOf('React\HttpClient\Request')
+            );
+
+        $request->on('error', $handler);
+
+        $request->writeHead();
+        $request->handleData("\r\n\r\n");
+    }
+
     /**
      * @test
      * @expectedException Exception


### PR DESCRIPTION
See https://github.com/reactphp/http/pull/65, https://github.com/reactphp/http-client/issues/81

Catches Guzzle InvalidArgumentException exception when invalid data are parsed via `gPsr\parse_response`