### PR TITLE
Consistent stream semantics and forward compatibility with upcoming Stream v1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,21 @@ Basic HTTP/1.0 client.
 
 ## Basic usage
 
-Requests are prepared using the ``Client#request()`` method. Body can be
-sent with ``Request#write()``. ``Request#end()`` finishes sending the request
-(or sends it at all if no body was written).
+Requests are prepared using the ``Client#request()`` method.
+
+The `Request#write(string $data)` method can be used to
+write data to the request body.
+Data will be buffered until the underlying connection is established, at which
+point buffered data will be sent and all further data will be passed to the
+underlying connection immediately.
+
+The `Request#end(?string $data = null)` method can be used to
+finish sending the request.
+You may optionally pass a last request body data chunk that will be sent just
+like a `write()` call.
+Calling this method finalizes the outgoing request body (which may be empty).
+Data will be buffered until the underlying connection is established, at which
+point buffered data will be sent and all further data will be ignored.
 
 Request implements WritableStreamInterface, so a Stream can be piped to it.
 Interesting events emitted by Request:

--- a/README.md
+++ b/README.md
@@ -10,17 +10,18 @@ Requests are prepared using the ``Client#request()`` method. Body can be
 sent with ``Request#write()``. ``Request#end()`` finishes sending the request
 (or sends it at all if no body was written).
 
-Request implements WritableStreamInterface, so a Stream can be piped to
-it. Response implements ReadableStreamInterface.
-
+Request implements WritableStreamInterface, so a Stream can be piped to it.
 Interesting events emitted by Request:
 
 * `response`: The response headers were received from the server and successfully
   parsed. The first argument is a Response instance.
+* `drain`: The outgoing buffer drained and the response is ready to accept more
+  data for the next `write()` call.
 * `error`: An error occurred.
 * `end`: The request is finished. If an error occurred, it is passed as first
   argument. Second and third arguments are the Response and the Request.
 
+Response implements ReadableStreamInterface.
 Interesting events emitted by Response:
 
 * `data`: Passes a chunk of the response body as first argument and a Response

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Calling this method finalizes the outgoing request body (which may be empty).
 Data will be buffered until the underlying connection is established, at which
 point buffered data will be sent and all further data will be ignored.
 
+The `Request#close()` method can be used to
+forefully close sending the request.
+Unlike the `end()` method, this method discards any buffers and closes the
+underlying connection.
+
 Request implements WritableStreamInterface, so a Stream can be piped to it.
 Interesting events emitted by Request:
 
@@ -29,18 +34,20 @@ Interesting events emitted by Request:
   parsed. The first argument is a Response instance.
 * `drain`: The outgoing buffer drained and the response is ready to accept more
   data for the next `write()` call.
-* `error`: An error occurred.
-* `end`: The request is finished. If an error occurred, it is passed as first
-  argument. Second and third arguments are the Response and the Request.
+* `error`: An error occurred, an `Exception` is passed as first argument.
+* `close`: The request is closed. If an error occurred, this event will be
+  preceeded by an `error` event.
 
 Response implements ReadableStreamInterface.
 Interesting events emitted by Response:
 
-* `data`: Passes a chunk of the response body as first argument and a Response
-  object itself as second argument. When a response encounters a chunked encoded response it will parse it transparently for the user of `Response` and removing the `Transfer-Encoding` header.
-* `error`: An error occurred.
-* `end`: The response has been fully received. If an error
-  occurred, it is passed as first argument.
+* `data`: Passes a chunk of the response body as first argument.
+  When a response encounters a chunked encoded response it will parse it
+  transparently for the user and removing the `Transfer-Encoding` header.
+* `error`: An error occurred, an `Exception` is passed as first argument.
+* `end`: The response has been fully received.
+* `close`: The response is closed. If an error occured, this event will be
+  preceeded by an `error` event.
 
 ### Example
 

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "guzzlehttp/psr7": "^1.0",
         "react/socket": "^0.7",
         "react/event-loop": "0.4.*",
-        "react/stream": "^0.5|^0.6",
+        "react/stream": "^1.0 || ^0.7 || ^0.6 || ^0.5 || ^0.4.2",
         "react/promise": "~2.2",
         "evenement/evenement": "~2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "guzzlehttp/psr7": "^1.0",
         "react/socket": "^0.7",
         "react/event-loop": "0.4.*",
-        "react/stream": "0.4.*",
+        "react/stream": "^0.5|^0.6",
         "react/promise": "~2.2",
         "evenement/evenement": "~2.0"
     },

--- a/src/Request.php
+++ b/src/Request.php
@@ -31,6 +31,7 @@ class Request implements WritableStreamInterface
     private $responseFactory;
     private $response;
     private $state = self::STATE_INIT;
+    private $ended = false;
 
     private $pendingWrites = '';
 
@@ -42,7 +43,7 @@ class Request implements WritableStreamInterface
 
     public function isWritable()
     {
-        return self::STATE_END > $this->state;
+        return self::STATE_END > $this->state && !$this->ended;
     }
 
     private function writeHead()
@@ -107,8 +108,8 @@ class Request implements WritableStreamInterface
 
     public function end($data = null)
     {
-        if (null !== $data && !is_scalar($data)) {
-            throw new \InvalidArgumentException('$data must be null or scalar');
+        if (!$this->isWritable()) {
+            return;
         }
 
         if (null !== $data) {
@@ -116,6 +117,8 @@ class Request implements WritableStreamInterface
         } else if (self::STATE_WRITING_HEAD > $this->state) {
             $this->writeHead();
         }
+
+        $this->ended = true;
     }
 
     /** @internal */

--- a/src/Response.php
+++ b/src/Response.php
@@ -75,6 +75,7 @@ class Response extends EventEmitter  implements ReadableStreamInterface
         return $this->headers;
     }
 
+    /** @internal */
     public function handleData($data)
     {
         if ($this->readable) {
@@ -82,15 +83,17 @@ class Response extends EventEmitter  implements ReadableStreamInterface
         }
     }
 
+    /** @internal */
     public function handleEnd()
     {
         if (!$this->readable) {
             return;
         }
-        $this->emit('end', array());
+        $this->emit('end');
         $this->close();
     }
 
+    /** @internal */
     public function handleError(\Exception $error)
     {
         if (!$this->readable) {
@@ -105,6 +108,7 @@ class Response extends EventEmitter  implements ReadableStreamInterface
         $this->close();
     }
 
+    /** @internal */
     public function handleClose()
     {
         $this->close();
@@ -117,11 +121,10 @@ class Response extends EventEmitter  implements ReadableStreamInterface
         }
 
         $this->readable = false;
-
-        $this->emit('close', array());
-
-        $this->removeAllListeners();
         $this->stream->close();
+
+        $this->emit('close');
+        $this->removeAllListeners();
     }
 
     public function isReadable()

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -5,6 +5,7 @@ namespace React\Tests\HttpClient;
 use React\HttpClient\Request;
 use React\HttpClient\RequestData;
 use React\Stream\Stream;
+use React\Stream\DuplexResourceStream;
 use React\Promise\RejectedPromise;
 use React\Promise\Deferred;
 use React\Promise\Promise;
@@ -428,7 +429,7 @@ class RequestTest extends TestCase
         $request->setResponseFactory($factory);
 
         $stream = fopen('php://memory', 'r+');
-        $stream = new Stream($stream, $loop);
+        $stream = class_exists('React\Stream\DuplexResourceStream') ? new DuplexResourceStream($stream, $loop) : new Stream($stream, $loop);
 
         $stream->pipe($request);
         $stream->emit('data', array('some'));

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -216,8 +216,7 @@ class RequestTest extends TestCase
         $handler->expects($this->once())
             ->method('__invoke')
             ->with(
-                $this->isInstanceOf('\InvalidArgumentException'),
-                $this->isInstanceOf('React\HttpClient\Request')
+                $this->isInstanceOf('\InvalidArgumentException')
             );
 
         $request->on('error', $handler);

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -52,21 +52,29 @@ class RequestTest extends TestCase
             ->method('on')
             ->with('error', $this->identicalTo(array($request, 'handleError')));
         $this->stream
-            ->expects($this->at(5))
-            ->method('removeListener')
-            ->with('drain', $this->identicalTo(array($request, 'handleDrain')));
+            ->expects($this->at(4))
+            ->method('on')
+            ->with('close', $this->identicalTo(array($request, 'handleClose')));
         $this->stream
             ->expects($this->at(6))
             ->method('removeListener')
-            ->with('data', $this->identicalTo(array($request, 'handleData')));
+            ->with('drain', $this->identicalTo(array($request, 'handleDrain')));
         $this->stream
             ->expects($this->at(7))
             ->method('removeListener')
-            ->with('end', $this->identicalTo(array($request, 'handleEnd')));
+            ->with('data', $this->identicalTo(array($request, 'handleData')));
         $this->stream
             ->expects($this->at(8))
             ->method('removeListener')
+            ->with('end', $this->identicalTo(array($request, 'handleEnd')));
+        $this->stream
+            ->expects($this->at(9))
+            ->method('removeListener')
             ->with('error', $this->identicalTo(array($request, 'handleError')));
+        $this->stream
+            ->expects($this->at(10))
+            ->method('removeListener')
+            ->with('close', $this->identicalTo(array($request, 'handleClose')));
 
         $response = $this->response;
 
@@ -76,7 +84,7 @@ class RequestTest extends TestCase
 
         $response->expects($this->at(0))
             ->method('on')
-            ->with('end', $this->anything())
+            ->with('close', $this->anything())
             ->will($this->returnCallback(function ($event, $cb) use (&$endCallback) {
                 $endCallback = $cb;
             }));
@@ -95,18 +103,13 @@ class RequestTest extends TestCase
             ->with($response);
 
         $request->on('response', $handler);
-        $request->on('close', $this->expectCallableNever());
+        $request->on('end', $this->expectCallableNever());
 
         $handler = $this->createCallableMock();
         $handler->expects($this->once())
-            ->method('__invoke')
-            ->with(
-                null,
-                $this->isInstanceof('React\HttpClient\Response'),
-                $this->isInstanceof('React\HttpClient\Request')
-            );
+            ->method('__invoke');
 
-        $request->on('end', $handler);
+        $request->on('close', $handler);
         $request->end();
 
         $request->handleData("HTTP/1.0 200 OK\r\n");
@@ -129,29 +132,23 @@ class RequestTest extends TestCase
         $handler->expects($this->once())
             ->method('__invoke')
             ->with(
-                $this->isInstanceOf('RuntimeException'),
-                $this->isInstanceOf('React\HttpClient\Request')
+                $this->isInstanceOf('RuntimeException')
             );
 
         $request->on('error', $handler);
 
         $handler = $this->createCallableMock();
         $handler->expects($this->once())
-            ->method('__invoke')
-            ->with(
-                $this->isInstanceOf('RuntimeException'),
-                null,
-                $this->isInstanceOf('React\HttpClient\Request')
-            );
+            ->method('__invoke');
 
-        $request->on('end', $handler);
-        $request->on('close', $this->expectCallableNever());
+        $request->on('close', $handler);
+        $request->on('end', $this->expectCallableNever());
 
         $request->end();
     }
 
     /** @test */
-    public function requestShouldEmitErrorIfConnectionEndsBeforeResponseIsParsed()
+    public function requestShouldEmitErrorIfConnectionClosesBeforeResponseIsParsed()
     {
         $requestData = new RequestData('GET', 'http://www.example.com');
         $request = new Request($this->connector, $requestData);
@@ -162,23 +159,17 @@ class RequestTest extends TestCase
         $handler->expects($this->once())
             ->method('__invoke')
             ->with(
-                $this->isInstanceOf('RuntimeException'),
-                $this->isInstanceOf('React\HttpClient\Request')
+                $this->isInstanceOf('RuntimeException')
             );
 
         $request->on('error', $handler);
 
         $handler = $this->createCallableMock();
         $handler->expects($this->once())
-            ->method('__invoke')
-            ->with(
-                $this->isInstanceOf('RuntimeException'),
-                null,
-                $this->isInstanceOf('React\HttpClient\Request')
-            );
+            ->method('__invoke');
 
-        $request->on('end', $handler);
-        $request->on('close', $this->expectCallableNever());
+        $request->on('close', $handler);
+        $request->on('end', $this->expectCallableNever());
 
         $request->end();
         $request->handleEnd();
@@ -196,23 +187,17 @@ class RequestTest extends TestCase
         $handler->expects($this->once())
             ->method('__invoke')
             ->with(
-                $this->isInstanceOf('Exception'),
-                $this->isInstanceOf('React\HttpClient\Request')
+                $this->isInstanceOf('Exception')
             );
 
         $request->on('error', $handler);
 
         $handler = $this->createCallableMock();
         $handler->expects($this->once())
-            ->method('__invoke')
-            ->with(
-                $this->isInstanceOf('Exception'),
-                null,
-                $this->isInstanceOf('React\HttpClient\Request')
-            );
+            ->method('__invoke');
 
-        $request->on('end', $handler);
-        $request->on('close', $this->expectCallableNever());
+        $request->on('close', $handler);
+        $request->on('end', $this->expectCallableNever());
 
         $request->end();
         $request->handleError(new \Exception('test'));
@@ -268,11 +253,11 @@ class RequestTest extends TestCase
         $this->successfulConnectionMock();
 
         $this->stream
-            ->expects($this->at(4))
+            ->expects($this->at(5))
             ->method('write')
             ->with($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\nUser-Agent:.*\r\n\r\n$#"));
         $this->stream
-            ->expects($this->at(5))
+            ->expects($this->at(6))
             ->method('write')
             ->with($this->identicalTo("some post data"));
 
@@ -298,19 +283,19 @@ class RequestTest extends TestCase
         $this->successfulConnectionMock();
 
         $this->stream
-            ->expects($this->at(4))
+            ->expects($this->at(5))
             ->method('write')
             ->with($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\nUser-Agent:.*\r\n\r\n$#"));
         $this->stream
-            ->expects($this->at(5))
+            ->expects($this->at(6))
             ->method('write')
             ->with($this->identicalTo("some"));
         $this->stream
-            ->expects($this->at(6))
+            ->expects($this->at(7))
             ->method('write')
             ->with($this->identicalTo("post"));
         $this->stream
-            ->expects($this->at(7))
+            ->expects($this->at(8))
             ->method('write')
             ->with($this->identicalTo("data"));
 
@@ -339,19 +324,19 @@ class RequestTest extends TestCase
         $resolveConnection = $this->successfulAsyncConnectionMock();
 
         $this->stream
-            ->expects($this->at(4))
+            ->expects($this->at(5))
             ->method('write')
             ->with($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\nUser-Agent:.*\r\n\r\n$#"));
         $this->stream
-            ->expects($this->at(5))
+            ->expects($this->at(6))
             ->method('write')
             ->with($this->identicalTo("some"));
         $this->stream
-            ->expects($this->at(6))
+            ->expects($this->at(7))
             ->method('write')
             ->with($this->identicalTo("post"));
         $this->stream
-            ->expects($this->at(7))
+            ->expects($this->at(8))
             ->method('write')
             ->with($this->identicalTo("data"));
 
@@ -386,19 +371,19 @@ class RequestTest extends TestCase
         $this->successfulConnectionMock();
 
         $this->stream
-            ->expects($this->at(4))
+            ->expects($this->at(5))
             ->method('write')
             ->with($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\nUser-Agent:.*\r\n\r\n$#"));
         $this->stream
-            ->expects($this->at(5))
+            ->expects($this->at(6))
             ->method('write')
             ->with($this->identicalTo("some"));
         $this->stream
-            ->expects($this->at(6))
+            ->expects($this->at(7))
             ->method('write')
             ->with($this->identicalTo("post"));
         $this->stream
-            ->expects($this->at(7))
+            ->expects($this->at(8))
             ->method('write')
             ->with($this->identicalTo("data"));
 
@@ -451,7 +436,7 @@ class RequestTest extends TestCase
 
         $response->expects($this->at(0))
             ->method('on')
-            ->with('end', $this->anything());
+            ->with('close', $this->anything());
         $response->expects($this->at(1))
             ->method('on')
             ->with('error', $this->anything())
@@ -482,11 +467,11 @@ class RequestTest extends TestCase
         $requestData = new RequestData('GET', 'http://www.example.com');
         $request = new Request($this->connector, $requestData);
 
-        $request->on('end', function () {});
-        $this->assertCount(1, $request->listeners('end'));
+        $request->on('close', function () {});
+        $this->assertCount(1, $request->listeners('close'));
 
         $request->close();
-        $this->assertCount(0, $request->listeners('end'));
+        $this->assertCount(0, $request->listeners('close'));
     }
 
     private function successfulConnectionMock()
@@ -530,7 +515,7 @@ class RequestTest extends TestCase
 
         $response->expects($this->at(0))
         ->method('on')
-        ->with('end', $this->anything());
+        ->with('close', $this->anything());
         $response->expects($this->at(1))
         ->method('on')
         ->with('error', $this->anything())

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -31,23 +31,31 @@ class ResponseTest extends TestCase
             ->expects($this->at(2))
             ->method('on')
             ->with('end', $this->anything());
+        $this->stream
+            ->expects($this->at(3))
+            ->method('on')
+            ->with('close', $this->anything());
 
         $response = new Response($this->stream, 'HTTP', '1.0', '200', 'OK', array('Content-Type' => 'text/plain'));
 
         $handler = $this->createCallableMock();
         $handler->expects($this->once())
             ->method('__invoke')
-            ->with('some data', $this->anything());
+            ->with('some data');
 
         $response->on('data', $handler);
 
         $handler = $this->createCallableMock();
         $handler->expects($this->once())
-            ->method('__invoke')
-            ->with(null, $this->isInstanceOf('React\HttpClient\Response'));
+            ->method('__invoke');
 
         $response->on('end', $handler);
-        $response->on('close', $this->expectCallableNever());
+
+        $handler = $this->createCallableMock();
+        $handler->expects($this->once())
+            ->method('__invoke');
+
+        $response->on('close', $handler);
 
         $this->stream
             ->expects($this->at(0))
@@ -106,7 +114,7 @@ class ResponseTest extends TestCase
         );
 
         $buffer = '';
-        $response->on('data', function ($data, $stream) use (&$buffer) {
+        $response->on('data', function ($data) use (&$buffer) {
             $buffer.= $data;
         });
         $this->assertSame('', $buffer);

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -11,8 +11,7 @@ class ResponseTest extends TestCase
 
     public function setUp()
     {
-        $this->stream = $this->getMockBuilder('React\Stream\Stream')
-            ->disableOriginalConstructor()
+        $this->stream = $this->getMockBuilder('React\Stream\DuplexStreamInterface')
             ->getMock();
     }
 


### PR DESCRIPTION
The `Request` is a `WritableStreamInterface` and now obeys its method and event semantics.
The `Response` is a `ReadableStreamInterface` and now obeys its method and event semantics.

Resolves / closes #70 
Supersedes / closes #83
Builds on top of / closes #87 (thanks @maciejmrozinski!)