### PR TITLE
Support OPTIONS method with asterisk-form (OPTIONS * HTTP/1.1)

### DIFF
--- a/src/RequestData.php
+++ b/src/RequestData.php
@@ -56,10 +56,18 @@ class RequestData
 
     public function getPath()
     {
-        $path = parse_url($this->url, PHP_URL_PATH) ?: '/';
+        $path = parse_url($this->url, PHP_URL_PATH);
         $queryString = parse_url($this->url, PHP_URL_QUERY);
 
-        return $path.($queryString ? "?$queryString" : '');
+        // assume "/" path by default, but allow "OPTIONS *"
+        if ($path === null) {
+            $path = ($this->method === 'OPTIONS' && $queryString === null) ? '*': '/';
+        }
+        if ($queryString !== null) {
+            $path .= '?' . $queryString;
+        }
+
+        return $path;
     }
 
     public function setProtocolVersion($version)

--- a/tests/RequestDataTest.php
+++ b/tests/RequestDataTest.php
@@ -20,6 +20,58 @@ class RequestDataTest extends TestCase
     }
 
     /** @test */
+    public function toStringReturnsHTTPRequestMessageWithEmptyQueryString()
+    {
+        $requestData = new RequestData('GET', 'http://www.example.com/path?hello=world');
+
+        $expected = "GET /path?hello=world HTTP/1.0\r\n" .
+            "Host: www.example.com\r\n" .
+            "User-Agent: React/alpha\r\n" .
+            "\r\n";
+
+        $this->assertSame($expected, $requestData->__toString());
+    }
+
+    /** @test */
+    public function toStringReturnsHTTPRequestMessageWithZeroQueryStringAndRootPath()
+    {
+        $requestData = new RequestData('GET', 'http://www.example.com?0');
+
+        $expected = "GET /?0 HTTP/1.0\r\n" .
+            "Host: www.example.com\r\n" .
+            "User-Agent: React/alpha\r\n" .
+            "\r\n";
+
+        $this->assertSame($expected, $requestData->__toString());
+    }
+
+    /** @test */
+    public function toStringReturnsHTTPRequestMessageWithOptionsAbsoluteRequestForm()
+    {
+        $requestData = new RequestData('OPTIONS', 'http://www.example.com/');
+
+        $expected = "OPTIONS / HTTP/1.0\r\n" .
+            "Host: www.example.com\r\n" .
+            "User-Agent: React/alpha\r\n" .
+            "\r\n";
+
+        $this->assertSame($expected, $requestData->__toString());
+    }
+
+    /** @test */
+    public function toStringReturnsHTTPRequestMessageWithOptionsAsteriskRequestForm()
+    {
+        $requestData = new RequestData('OPTIONS', 'http://www.example.com');
+
+        $expected = "OPTIONS * HTTP/1.0\r\n" .
+            "Host: www.example.com\r\n" .
+            "User-Agent: React/alpha\r\n" .
+            "\r\n";
+
+        $this->assertSame($expected, $requestData->__toString());
+    }
+
+    /** @test */
     public function toStringReturnsHTTPRequestMessageWithProtocolVersion()
     {
         $requestData = new RequestData('GET', 'http://www.example.com');


### PR DESCRIPTION
The OPTIONS method now uses asterisk-form if no request path has been given, for example `http://google.com` instead of `http://google.com/` (note the trailing slash).

See https://tools.ietf.org/html/rfc7230#section-5.3.4 and https://tools.ietf.org/html/rfc7231#section-4.3.7