### PR TITLE
Fix merging default headers if overwritten with custom case headers

### DIFF
--- a/src/RequestData.php
+++ b/src/RequestData.php
@@ -23,15 +23,24 @@ class RequestData
         $connectionHeaders = ('1.1' === $this->protocolVersion) ? array('Connection' => 'close') : array();
         $authHeaders = $this->getAuthHeaders();
 
-        return array_merge(
+        $defaults = array_merge(
             array(
                 'Host'          => $this->getHost().$port,
                 'User-Agent'    => 'React/alpha',
             ),
             $connectionHeaders,
-            $authHeaders,
-            $headers
+            $authHeaders
         );
+
+        // remove all defaults that already exist in $headers
+        $lower = array_change_key_case($headers, CASE_LOWER);
+        foreach ($defaults as $key => $_) {
+            if (isset($lower[strtolower($key)])) {
+                unset($defaults[$key]);
+            }
+        }
+
+        return array_merge($defaults, $headers);
     }
 
     public function getScheme()

--- a/tests/RequestDataTest.php
+++ b/tests/RequestDataTest.php
@@ -55,6 +55,23 @@ class RequestDataTest extends TestCase
     }
 
     /** @test */
+    public function toStringReturnsHTTPRequestMessageWithHeadersInCustomCase()
+    {
+        $requestData = new RequestData('GET', 'http://www.example.com', array(
+            'user-agent' => 'Hello',
+            'LAST' => 'World'
+        ));
+
+        $expected = "GET / HTTP/1.0\r\n" .
+            "Host: www.example.com\r\n" .
+            "user-agent: Hello\r\n" .
+            "LAST: World\r\n" .
+            "\r\n";
+
+        $this->assertSame($expected, $requestData->__toString());
+    }
+
+    /** @test */
     public function toStringReturnsHTTPRequestMessageWithProtocolVersionThroughConstructor()
     {
         $requestData = new RequestData('GET', 'http://www.example.com', [], '1.1');


### PR DESCRIPTION
The `Client` always tried to add a `Host` header, unless an explicit `Host` header value is already given. This change makes sure that explicit headers are matched case insensitive, so that a `host` header will also be taken into account and will be preserved as-is, without adding a duplicate `Host` header as well.

Refs #100