### PR TITLE
Lock Travis distro so new defaults will not break the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,13 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - nightly
+  - nightly # ignore errors, see below
+  - hhvm # ignore errors, see below
 
 # lock distro so new future defaults will not break the build
-dist: precise
+dist: trusty
 
-# also test against HHVM, but require "trusty" and ignore errors
 matrix:
-  include:
-    - php: hhvm
-      dist: trusty
   allow_failures:
     - php: nightly
     - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ php:
   - 7.1
   - nightly
 
+# lock distro so new future defaults will not break the build
+dist: precise
+
 # also test against HHVM, but require "trusty" and ignore errors
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,12 @@ php:
   - 7.0
   - 7.1
   - nightly
-  - hhvm
 
+# also test against HHVM, but require "trusty" and ignore errors
 matrix:
+  include:
+    - php: hhvm
+      dist: trusty
   allow_failures:
     - php: nightly
     - php: hhvm


### PR DESCRIPTION
Travis is in the process of upgrading the base distro (https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming) and despite all PRs currently being "green", may start to mark the current master as broken. Unlike reactphp/stream#110 this project is not affected by Travis dropping support for older versions of PHP.

Originally from clue/php-connection-manager-extra#24