### PR TITLE
Target evenement 3.0 a long side 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "react/socket": "^1.0 || ^0.8 || ^0.7",
         "react/stream": "^1.0 || ^0.7 || ^0.6 || ^0.5 || ^0.4.2",
         "react/promise": "~2.2",
-        "evenement/evenement": "~2.0"
+        "evenement/evenement": "^3.0 || ^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0 || ^4.8.10"


### PR DESCRIPTION
Événement `3.0` is nearly fully backwards compatible with `2.0` and `react/http-client` is fully compatible with all three so why not support it. It packs some neat performance upgrades without any code changes on `react/http-client`'s side :shipit: .