### PR TITLE
Update Socket dependency to support hosts file on all platforms

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=5.4.0",
         "guzzlehttp/psr7": "^1.0",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
-        "react/socket": "^1.0 || ^0.8 || ^0.7",
+        "react/socket": "^1.0 || ^0.8.2",
         "react/stream": "^1.0 || ^0.7 || ^0.6 || ^0.5 || ^0.4.2",
         "react/promise": "~2.2",
         "evenement/evenement": "^3.0 || ^2.0"


### PR DESCRIPTION
The underlying `Connector` now honors the hosts file on all platforms by default. This means that you can now send requests to `localhost` etc..

Resolves / closes #11
Refs reactphp/socket#112