### PR TITLE
Fix ignoring invalid incoming Transfer-Encoding response header

### DIFF
--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -129,5 +129,36 @@ class ResponseTest extends TestCase
             $response->getHeaders()
         );
     }
+
+    /** @test */
+    public function doubleChunkedEncodingResponseWillBePassedAsIs()
+    {
+        $stream = new ThroughStream();
+        $response = new Response(
+            $stream,
+            'http',
+            '1.0',
+            '200',
+            'ok',
+            array(
+                'content-type' => 'text/plain',
+                'transfer-encoding' => array(
+                    'chunked',
+                    'chunked'
+                )
+            )
+        );
+
+        $this->assertSame(
+            array(
+                'content-type' => 'text/plain',
+                'transfer-encoding' => array(
+                    'chunked',
+                    'chunked'
+                )
+            ),
+            $response->getHeaders()
+        );
+    }
 }
 


### PR DESCRIPTION
With this change applied, the `Response` will no longer try to decode incoming responses that use the (invalid) `Transfer-Encoding: chunked, chunked` header. This PR adds a few helper methods that are inspired by PSR-7. Exposing these as part of the public API is left up for #41.

Resolves / closes #117
Builds on top of #58