### PR TITLE
Replace Guzzle with RingCentral

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,12 +5,12 @@
     "license": "MIT",
     "require": {
         "php": ">=5.4.0",
-        "guzzlehttp/psr7": "^1.0",
+        "evenement/evenement": "^3.0 || ^2.0",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
         "react/socket": "^1.0 || ^0.8.4",
         "react/stream": "^1.0 || ^0.7.1",
         "react/promise": "~2.2",
-        "evenement/evenement": "^3.0 || ^2.0"
+        "ringcentral/psr7": "^1.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.4 || ^5.7 || ^4.8.35"

--- a/src/Request.php
+++ b/src/Request.php
@@ -3,11 +3,11 @@
 namespace React\HttpClient;
 
 use Evenement\EventEmitterTrait;
-use GuzzleHttp\Psr7 as gPsr;
 use React\Promise;
+use React\Socket\ConnectionInterface;
 use React\Socket\ConnectorInterface;
 use React\Stream\WritableStreamInterface;
-use React\Socket\ConnectionInterface;
+use RingCentral\Psr7 as gPsr;
 
 /**
  * @event response


### PR DESCRIPTION
This replaces Guzzle's PSR-7 implementation with RingCentral's. This is an internal change only and does not affect our API. This helps bringing this component more in line with the react/http component (see also https://github.com/reactphp/http/pull/101 and https://github.com/reactphp/http-client/issues/78).