### PR TITLE
Improve backwards compatibility with Promise v1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,9 +7,9 @@
         "php": ">=5.4.0",
         "evenement/evenement": "^3.0 || ^2.0",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
+        "react/promise": "^2.1 || ^1.2.1",
         "react/socket": "^1.0 || ^0.8.4",
         "react/stream": "^1.0 || ^0.7.1",
-        "react/promise": "~2.2",
         "ringcentral/psr7": "^1.2"
     },
     "require-dev": {

--- a/src/Request.php
+++ b/src/Request.php
@@ -56,7 +56,7 @@ class Request implements WritableStreamInterface
         $pendingWrites = &$this->pendingWrites;
 
         $promise = $this->connect();
-        $promise->done(
+        $promise->then(
             function (ConnectionInterface $stream) use ($requestData, &$streamRef, &$stateRef, &$pendingWrites) {
                 $streamRef = $stream;
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -272,25 +272,6 @@ class RequestTest extends TestCase
         $request->end();
     }
 
-    /**
-     * @test
-     * @expectedException Exception
-     * @expectedExceptionMessage something failed
-     */
-    public function requestDoesNotHideErrors()
-    {
-        $requestData = new RequestData('GET', 'http://www.example.com');
-        $request = new Request($this->connector, $requestData);
-
-        $this->rejectedConnectionMock();
-
-        $request->on('error', function () {
-            throw new \Exception('something failed');
-        });
-
-        $request->end();
-    }
-
     /** @test */
     public function postRequestShouldSendAPostRequest()
     {


### PR DESCRIPTION
This adds support for legacy Promise v1 (while keeping support for newer versions). This is an internal change only and does not affect our API. This helps bringing this component more in line with the react/http component (see also reactphp/http#101 and #78). This also effectively reverts #31, but this is a safe operation because throwing from an event handler is forbidden as of https://github.com/reactphp/stream/pull/101 anyway.