### PR TITLE
[RFC] Improve compatibility with legacy versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+# - 5.3 # requires old distro
   - 5.4
   - 5.5
   - 5.6
@@ -14,6 +15,9 @@ php:
 dist: trusty
 
 matrix:
+  include:
+    - php: 5.3
+      dist: precise
   allow_failures:
     - php: nightly
     - php: hhvm

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ $ composer require react/http-client:^0.5.7
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 
 This project aims to run on any platform and thus does not require any PHP
-extensions and supports running on legacy PHP 5.4 through current PHP 7+ and
+extensions and supports running on legacy PHP 5.3 through current PHP 7+ and
 HHVM.
 It's *highly recommended to use PHP 7+* for this project.
 

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "keywords": ["http"],
     "license": "MIT",
     "require": {
-        "php": ">=5.4.0",
-        "evenement/evenement": "^3.0 || ^2.0",
+        "php": ">=5.3.0",
+        "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
         "react/promise": "^2.1 || ^1.2.1",
         "react/socket": "^1.0 || ^0.8.4",

--- a/src/ChunkedStreamDecoder.php
+++ b/src/ChunkedStreamDecoder.php
@@ -2,7 +2,7 @@
 
 namespace React\HttpClient;
 
-use Evenement\EventEmitterTrait;
+use Evenement\EventEmitter;
 use Exception;
 use React\Stream\ReadableStreamInterface;
 use React\Stream\Util;
@@ -11,11 +11,9 @@ use React\Stream\WritableStreamInterface;
 /**
  * @internal
  */
-class ChunkedStreamDecoder implements ReadableStreamInterface
+class ChunkedStreamDecoder extends EventEmitter implements ReadableStreamInterface
 {
     const CRLF = "\r\n";
-
-    use EventEmitterTrait;
 
     /**
      * @var string
@@ -55,9 +53,9 @@ class ChunkedStreamDecoder implements ReadableStreamInterface
         $this->stream = $stream;
         $this->stream->on('data', array($this, 'handleData'));
         $this->stream->on('end',  array($this, 'handleEnd'));
-        Util::forwardEvents($this->stream, $this, [
+        Util::forwardEvents($this->stream, $this, array(
             'error',
-        ]);
+        ));
     }
 
     /** @internal */
@@ -89,9 +87,9 @@ class ChunkedStreamDecoder implements ReadableStreamInterface
         if ($this->nextChunkIsLength) {
             $crlfPosition = strpos($this->buffer, static::CRLF);
             if ($crlfPosition === false && strlen($this->buffer) > 1024) {
-                $this->emit('error', [
+                $this->emit('error', array(
                     new Exception('Chunk length header longer then 1024 bytes'),
-                ]);
+                ));
                 $this->close();
                 return false;
             }
@@ -114,9 +112,9 @@ class ChunkedStreamDecoder implements ReadableStreamInterface
             }
             $this->nextChunkIsLength = false;
             if (dechex(hexdec($lengthChunk)) !== strtolower($lengthChunk)) {
-                $this->emit('error', [
+                $this->emit('error', array(
                     new Exception('Unable to validate "' . $lengthChunk . '" as chunk length header'),
-                ]);
+                ));
                 $this->close();
                 return false;
             }
@@ -200,9 +198,9 @@ class ChunkedStreamDecoder implements ReadableStreamInterface
 
         $this->emit(
             'error',
-            [
+            array(
                 new Exception('Stream ended with incomplete control code')
-            ]
+            )
         );
         $this->close();
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -19,7 +19,7 @@ class Client
         $this->connector = $connector;
     }
 
-    public function request($method, $url, array $headers = [], $protocolVersion = '1.0')
+    public function request($method, $url, array $headers = array(), $protocolVersion = '1.0')
     {
         $requestData = new RequestData($method, $url, $headers, $protocolVersion);
 

--- a/src/RequestData.php
+++ b/src/RequestData.php
@@ -9,7 +9,7 @@ class RequestData
     private $headers;
     private $protocolVersion;
 
-    public function __construct($method, $url, array $headers = [], $protocolVersion = '1.0')
+    public function __construct($method, $url, array $headers = array(), $protocolVersion = '1.0')
     {
         $this->method = $method;
         $this->url = $url;

--- a/src/Response.php
+++ b/src/Response.php
@@ -12,9 +12,8 @@ use React\Stream\WritableStreamInterface;
  * @event error
  * @event end
  */
-class Response extends EventEmitter  implements ReadableStreamInterface
+class Response extends EventEmitter implements ReadableStreamInterface
 {
-
     private $stream;
     private $protocol;
     private $version;
@@ -166,7 +165,7 @@ class Response extends EventEmitter  implements ReadableStreamInterface
         $this->stream->resume();
     }
 
-    public function pipe(WritableStreamInterface $dest, array $options = [])
+    public function pipe(WritableStreamInterface $dest, array $options = array())
     {
         Util::pipe($this, $dest, $options);
 

--- a/tests/DecodeChunkedStreamTest.php
+++ b/tests/DecodeChunkedStreamTest.php
@@ -10,81 +10,81 @@ class DecodeChunkedStreamTest extends TestCase
 {
     public function provideChunkedEncoding()
     {
-        return [
-            'data-set-1' => [
-                ["4\r\nWiki\r\n5\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n"],
-            ],
-            'data-set-2' => [
-                ["4\r\nWiki\r\n", "5\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n"],
-            ],
-            'data-set-3' => [
-                ["4\r\nWiki\r\n", "5\r\n", "pedia\r\ne\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n"],
-            ],
-            'data-set-4' => [
-                ["4\r\nWiki\r\n", "5\r\n", "pedia\r\ne\r\n in\r\n", "\r\nchunks.\r\n0\r\n\r\n"],
-            ],
-            'data-set-5' => [
-                ["4\r\n", "Wiki\r\n", "5\r\n", "pedia\r\ne\r\n in\r\n", "\r\nchunks.\r\n0\r\n\r\n"],
-            ],
-            'data-set-6' => [
-                ["4\r\n", "Wiki\r\n", "5\r\n", "pedia\r\ne; foo=[bar,beer,pool,cue,win,won]\r\n", " in\r\n", "\r\nchunks.\r\n0\r\n\r\n"],
-            ],
-            'header-fields' => [
-                ["4; foo=bar\r\n", "Wiki\r\n", "5\r\n", "pedia\r\ne\r\n", " in\r\n", "\r\nchunks.\r\n", "0\r\n\r\n"],
-            ],
-            'character-for-charactrr' => [
+        return array(
+            'data-set-1' => array(
+                array("4\r\nWiki\r\n5\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n"),
+            ),
+            'data-set-2' => array(
+                array("4\r\nWiki\r\n", "5\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n"),
+            ),
+            'data-set-3' => array(
+                array("4\r\nWiki\r\n", "5\r\n", "pedia\r\ne\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n"),
+            ),
+            'data-set-4' => array(
+                array("4\r\nWiki\r\n", "5\r\n", "pedia\r\ne\r\n in\r\n", "\r\nchunks.\r\n0\r\n\r\n"),
+            ),
+            'data-set-5' => array(
+                array("4\r\n", "Wiki\r\n", "5\r\n", "pedia\r\ne\r\n in\r\n", "\r\nchunks.\r\n0\r\n\r\n"),
+            ),
+            'data-set-6' => array(
+                array("4\r\n", "Wiki\r\n", "5\r\n", "pedia\r\ne; foo=[bar,beer,pool,cue,win,won]\r\n", " in\r\n", "\r\nchunks.\r\n0\r\n\r\n"),
+            ),
+            'header-fields' => array(
+                array("4; foo=bar\r\n", "Wiki\r\n", "5\r\n", "pedia\r\ne\r\n", " in\r\n", "\r\nchunks.\r\n", "0\r\n\r\n"),
+            ),
+            'character-for-charactrr' => array(
                 str_split("4\r\nWiki\r\n5\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n"),
-            ],
-            'extra-newline-in-wiki-character-for-chatacter' => [
+            ),
+            'extra-newline-in-wiki-character-for-chatacter' => array(
                 str_split("6\r\nWi\r\nki\r\n5\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n"),
                 "Wi\r\nkipedia in\r\n\r\nchunks."
-            ],
-            'extra-newline-in-wiki' => [
-                ["6\r\nWi\r\n", "ki\r\n5\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n"],
+            ),
+            'extra-newline-in-wiki' => array(
+                array("6\r\nWi\r\n", "ki\r\n5\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n"),
                 "Wi\r\nkipedia in\r\n\r\nchunks."
-            ],
-            'varnish-type-response-1' => [
-                ["0017\r\nWikipedia in\r\n\r\nchunks.\r\n0\r\n\r\n"]
-            ],
-            'varnish-type-response-2' => [
-                ["000017\r\nWikipedia in\r\n\r\nchunks.\r\n0\r\n\r\n"]
-            ],
-            'varnish-type-response-3' => [
-                ["017\r\nWikipedia in\r\n\r\nchunks.\r\n0\r\n\r\n"]
-            ],
-            'varnish-type-response-4' => [
-                ["004\r\nWiki\r\n005\r\npedia\r\n00e\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n"]
-            ],
-            'varnish-type-response-5' => [
-                ["000004\r\nWiki\r\n00005\r\npedia\r\n000e\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n"]
-            ],
-            'varnish-type-response-extra-line' => [
-                ["006\r\nWi\r\nki\r\n005\r\npedia\r\n00e\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n"],
+            ),
+            'varnish-type-response-1' => array(
+                array("0017\r\nWikipedia in\r\n\r\nchunks.\r\n0\r\n\r\n")
+            ),
+            'varnish-type-response-2' => array(
+                array("000017\r\nWikipedia in\r\n\r\nchunks.\r\n0\r\n\r\n")
+            ),
+            'varnish-type-response-3' => array(
+                array("017\r\nWikipedia in\r\n\r\nchunks.\r\n0\r\n\r\n")
+            ),
+            'varnish-type-response-4' => array(
+                array("004\r\nWiki\r\n005\r\npedia\r\n00e\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n")
+            ),
+            'varnish-type-response-5' => array(
+                array("000004\r\nWiki\r\n00005\r\npedia\r\n000e\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n")
+            ),
+            'varnish-type-response-extra-line' => array(
+                array("006\r\nWi\r\nki\r\n005\r\npedia\r\n00e\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n"),
                 "Wi\r\nkipedia in\r\n\r\nchunks."
-            ],
-            'varnish-type-response-random' => [
-                [str_repeat("0", rand(0, 10)), "4\r\nWiki\r\n", str_repeat("0", rand(0, 10)), "5\r\npedia\r\n", str_repeat("0", rand(0, 10)), "e\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n"]
-            ],
-            'end-chunk-zero-check-1' => [
-                ["4\r\nWiki\r\n5\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n00\r\n\r\n"]
-            ],
-            'end-chunk-zero-check-2' => [
-                ["4\r\nWiki\r\n5\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n000\r\n\r\n"]
-            ],
-            'end-chunk-zero-check-3' => [
-                ["00004\r\nWiki\r\n005\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n0000\r\n\r\n"]
-            ],
-            'uppercase-chunk' => [
-                ["4\r\nWiki\r\n5\r\npedia\r\nE\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n"],
-            ],
-            'extra-space-in-length-chunk' => [
-                [" 04 \r\nWiki\r\n5\r\npedia\r\nE\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n"],
-            ],
-            'only-whitespace-is-final-chunk' => [
-                ["   \r\n\r\n"],
+            ),
+            'varnish-type-response-random' => array(
+                array(str_repeat("0", rand(0, 10)), "4\r\nWiki\r\n", str_repeat("0", rand(0, 10)), "5\r\npedia\r\n", str_repeat("0", rand(0, 10)), "e\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n")
+            ),
+            'end-chunk-zero-check-1' => array(
+                array("4\r\nWiki\r\n5\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n00\r\n\r\n")
+            ),
+            'end-chunk-zero-check-2' => array(
+                array("4\r\nWiki\r\n5\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n000\r\n\r\n")
+            ),
+            'end-chunk-zero-check-3' => array(
+                array("00004\r\nWiki\r\n005\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n0000\r\n\r\n")
+            ),
+            'uppercase-chunk' => array(
+                array("4\r\nWiki\r\n5\r\npedia\r\nE\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n"),
+            ),
+            'extra-space-in-length-chunk' => array(
+                array(" 04 \r\nWiki\r\n5\r\npedia\r\nE\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n"),
+            ),
+            'only-whitespace-is-final-chunk' => array(
+                array("   \r\n\r\n"),
                 ""
-            ]
-        ];
+            )
+        );
     }
 
     /**
@@ -110,17 +110,17 @@ class DecodeChunkedStreamTest extends TestCase
 
     public function provideInvalidChunkedEncoding()
     {
-        return [
-            'chunk-body-longer-than-header-suggests' => [
-                ["4\r\nWiwot40n98w3498tw3049nyn039409t34\r\n", "ki\r\n5\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n"],
-            ],
-            'invalid-header-charactrrs' => [
+        return array(
+            'chunk-body-longer-than-header-suggests' => array(
+                array("4\r\nWiwot40n98w3498tw3049nyn039409t34\r\n", "ki\r\n5\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n"),
+            ),
+            'invalid-header-charactrrs' => array(
                 str_split("xyz\r\nWi\r\nki\r\n5\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n")
-            ],
-            'header-chunk-to-long' => [
+            ),
+            'header-chunk-to-long' => array(
                 str_split(str_repeat('a', 2015) . "\r\nWi\r\nki\r\n5\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n")
-            ]
-        ];
+            )
+        );
     }
 
     /**
@@ -142,10 +142,10 @@ class DecodeChunkedStreamTest extends TestCase
 
     public function provideZeroChunk()
     {
-        return [
-            ['1-zero' => "0\r\n\r\n"],
-            ['random-zero' => str_repeat("0", rand(2, 10))."\r\n\r\n"]
-        ];
+        return array(
+            array('1-zero' => "0\r\n\r\n"),
+            array('random-zero' => str_repeat("0", rand(2, 10))."\r\n\r\n")
+        );
     }
 
     /**

--- a/tests/RequestDataTest.php
+++ b/tests/RequestDataTest.php
@@ -126,7 +126,7 @@ class RequestDataTest extends TestCase
     /** @test */
     public function toStringReturnsHTTPRequestMessageWithProtocolVersionThroughConstructor()
     {
-        $requestData = new RequestData('GET', 'http://www.example.com', [], '1.1');
+        $requestData = new RequestData('GET', 'http://www.example.com', array(), '1.1');
 
         $expected = "GET / HTTP/1.1\r\n" .
             "Host: www.example.com\r\n" .

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -634,8 +634,9 @@ class RequestTest extends TestCase
             ->with('www.example.com:80')
             ->will($this->returnValue($deferred->promise()));
 
-        return function () use ($deferred) {
-            $deferred->resolve($this->stream);
+        $stream = $this->stream;
+        return function () use ($deferred, $stream) {
+            $deferred->resolve($stream);
         };
     }
 
@@ -699,7 +700,7 @@ class RequestTest extends TestCase
 
         $this->stream->expects($this->once())
             ->method('emit')
-            ->with('data', ["1\r\nb\r"]);
+            ->with('data', array("1\r\nb\r"));
 
         $request->handleData("HTTP/1.0 200 OK\r\n");
         $request->handleData("Transfer-Encoding: chunked\r\n");

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -64,9 +64,9 @@ class ResponseTest extends TestCase
         $response->handleEnd();
 
         $this->assertSame(
-            [
+            array(
                 'Content-Type' => 'text/plain'
-            ],
+            ),
             $response->getHeaders()
         );
     }
@@ -89,9 +89,9 @@ class ResponseTest extends TestCase
         $response->pause();
 
         $this->assertSame(
-            [
+            array(
                 'content-type' => 'text/plain',
-            ],
+            ),
             $response->getHeaders()
         );
     }
@@ -106,10 +106,10 @@ class ResponseTest extends TestCase
             '1.0',
             '200',
             'ok',
-            [
+            array(
                 'content-type' => 'text/plain',
                 'transfer-encoding' => 'chunked',
-            ]
+            )
         );
 
         $buffer = '';
@@ -123,9 +123,9 @@ class ResponseTest extends TestCase
         $this->assertSame('Wiki', $buffer);
 
         $this->assertSame(
-            [
+            array(
                 'content-type' => 'text/plain',
-            ],
+            ),
             $response->getHeaders()
         );
     }


### PR DESCRIPTION
Because _why not_… :-)

Now more seriously: This project is a low level lib that is used as a building block for quite a few higher level abstractions on top of it. As such, compatibility (even with significantly outdated versions) is a major concern to me.

Note that I'm not suggesting putting _significant amount_ of work into this. The patch is already here and, personally, I see little harm in supporting this.

Also note that I'm not suggesting we need to keep support indefinitely. Should this ever turn out to be a burden in the future, e.g. because we actually _require_ any new language features or some external lib, then I'm all for dropping support again. If you want to discuss this further, I would suggest directing this to https://github.com/reactphp/react/issues/374 instead 👍 

Supersedes / closes #119