### PR TITLE
Support legacy HTTP servers that use only LF instead of CRLF

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -134,7 +134,8 @@ class Request extends EventEmitter implements WritableStreamInterface
     {
         $this->buffer .= $data;
 
-        if (false !== strpos($this->buffer, "\r\n\r\n")) {
+        // buffer until double CRLF (or double LF for compatibility with legacy servers)
+        if (false !== strpos($this->buffer, "\r\n\r\n") || false !== strpos($this->buffer, "\n\n")) {
             try {
                 list($response, $bodyChunk) = $this->parseResponse($this->buffer);
             } catch (\InvalidArgumentException $exception) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -26,6 +26,17 @@ class TestCase extends BaseTestCase
         return $mock;
     }
 
+    protected function expectCallableOnceWith($value)
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($value);
+
+        return $mock;
+    }
+
     protected function expectCallableNever()
     {
         $mock = $this->createCallableMock();


### PR DESCRIPTION
As per https://tools.ietf.org/html/rfc7230#section-3.5 HTTP would require a CRLF, but apparently also accept a LF for robustness with legacy systems.

Resolves / closes #129 