### PR TITLE
Link to clue/reactphp-buzz for higher-level HTTP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 
 Event-driven, streaming HTTP client for [ReactPHP](https://reactphp.org).
 
+> Note that this is a very low-level HTTP client implementation that is currently
+  undergoing some major changes. In the meantime, we recommend using
+  [clue/reactphp-buzz](https://github.com/clue/reactphp-buzz) as a higher-level
+  HTTP client abstraction (which happens to build on top of this project). It
+  provides a Promise-based interface and common PSR-7 message abstraction which
+  makes getting started much easier.
+
 **Table of Contents**
 
 * [Basic usage](#basic-usage)


### PR DESCRIPTION
This is a very low-level HTTP client implementation that is currently undergoing some major changes. In the meantime, we recommend using [clue/reactphp-buzz](https://github.com/clue/reactphp-buzz) as a higher-level HTTP client abstraction (which happens to build on top of this project).

The idea is that this should ease the learning curve for people new to ReactPHP that may otherwise struggle with flaws of the current API. This remark should be removed again once we have reworked the API and/or when it is merged into the HTTP component (#78).