### PR TITLE
Uppercase http & https

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -248,7 +248,7 @@ class Request extends EventEmitter implements WritableStreamInterface
     protected function connect()
     {
         $scheme = $this->requestData->getScheme();
-        if ($scheme !== 'https' && $scheme !== 'http') {
+        if ($scheme !== 'https' && $scheme !== 'http' && $scheme !== 'HTTPS' && $scheme !== 'HTTP') {
             return Promise\reject(
                 new \InvalidArgumentException('Invalid request URL given')
             );


### PR DESCRIPTION
When used to call back notifications, the URLs transmitted are somewhat unregulated. Adding uppercase protocol names to enhance robustness.