### PR TITLE
Add request maximum timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Event-driven, streaming HTTP client for [ReactPHP](https://reactphp.org).
 
 * [Basic usage](#basic-usage)
   * [Client](#client)
+  * [Request Timeouts](#request-timeouts)
   * [Example](#example)
 * [Advanced usage](#advanced-usage)
   * [Unix domain sockets](#unix-domain-sockets)
@@ -112,6 +113,19 @@ Interesting events emitted by Response:
   preceeded by an `error` event.
   This will also be forwarded to the request and emit a `close` event there.
 
+### Request Timeouts
+
+Each request can have their own separate maximum timeout
+(connection timeout is implemented in the [`react/socket`](https://github.com/reactphp/socket) component).
+The maximum timeout is measured from the start of the request until the end of the response (completely received).
+
+The maximum time for a request to take can be set for each `Request` using their `setTimeout` method.
+The method takes a single argument indicating the timeout in seconds (as integer or float).
+
+The timeout has to be set before the request starts.
+Once the timeout is reached, a `React\HttpClient\TimeoutException` will be emitted as `error` event.
+The stream will be forcefully closed.
+
 ### Example
 
 ```php
@@ -129,9 +143,13 @@ $request->on('response', function ($response) {
         echo 'DONE';
     });
 });
-$request->on('error', function (\Exception $e) {
+$request->on('error', function (Exception $e) {
     echo $e;
 });
+
+// allow the request to take 30 seconds
+$request->setTimeout(30.0); 
+
 $request->end();
 $loop->run();
 ```

--- a/src/Client.php
+++ b/src/Client.php
@@ -8,6 +8,7 @@ use React\Socket\Connector;
 
 class Client
 {
+    private $loop;
     private $connector;
 
     public function __construct(LoopInterface $loop, ConnectorInterface $connector = null)
@@ -16,6 +17,7 @@ class Client
             $connector = new Connector($loop);
         }
 
+        $this->loop = $loop;
         $this->connector = $connector;
     }
 
@@ -23,6 +25,9 @@ class Client
     {
         $requestData = new RequestData($method, $url, $headers, $protocolVersion);
 
-        return new Request($this->connector, $requestData);
+        $request = new Request($this->connector, $requestData);
+        $request->setLoop($this->loop);
+
+        return $request;
     }
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -70,10 +70,11 @@ class Request extends EventEmitter implements WritableStreamInterface
     {
         $this->state = self::STATE_WRITING_HEAD;
         $that = $this;
+        $timeout = $this->timeout;
 
-        if ($this->timeout > 0.0) {
-            $this->timeoutTimer = $this->loop->addTimer($this->timeout, function () use ($that) {
-                $that->closeError(new TimeoutException('The request took longer than expected ('.$that->timeout.' seconds)'));
+        if ($timeout > 0.0) {
+            $this->timeoutTimer = $this->loop->addTimer($this->timeout, function () use ($that, $timeout) {
+                $that->closeError(new TimeoutException('The request took longer than expected ('.$timeout.' seconds)'));
             });
         }
 

--- a/src/TimeoutException.php
+++ b/src/TimeoutException.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace React\HttpClient;
+
+use RuntimeException;
+
+class TimeoutException extends RuntimeException {
+    
+}


### PR DESCRIPTION
This PR adds an optional maximum timeout for requests. The maximum timeout is measured from the start of the request (just before connecting) to the end of the response.

To allow this to be implemented in a non-BC way, I've added two methods to the `Request` class which should be moved into the constructor in the next major version.

The event loop is automatically set in the `Client` after creating the `Request` and as such the method is marked as internal.

I've added documentation to the README and tests. I'm not completely sure if the tests are okay, so these should be verified.

Resolves #28.