### PR TITLE
Minimal fix for PHP 8

### DIFF
--- a/src/ChunkedStreamDecoder.php
+++ b/src/ChunkedStreamDecoder.php
@@ -111,7 +111,7 @@ class ChunkedStreamDecoder extends EventEmitter implements ReadableStreamInterfa
                 }
             }
             $this->nextChunkIsLength = false;
-            if (dechex(@hexdec($lengthChunk)) !== strtolower($lengthChunk)) {
+            if (dechex((int)@hexdec($lengthChunk)) !== strtolower($lengthChunk)) {
                 $this->emit('error', array(
                     new Exception('Unable to validate "' . $lengthChunk . '" as chunk length header'),
                 ));


### PR DESCRIPTION
To avoid TypeError when overflow to float

Don't know if it worth to be fixed as deprecated component... BTW, minor patch